### PR TITLE
Fix Warning V3093

### DIFF
--- a/Histacom2/OS/Win98/Win98Apps/WebChat1999.cs
+++ b/Histacom2/OS/Win98/Win98Apps/WebChat1999.cs
@@ -143,8 +143,8 @@ namespace Histacom2.OS.Win98.Win98Apps
             switch (chatStage)
             {
                 case 1: // td asks are you the time distorter guy
-                    if (msg.Contains("yes") | msg.Contains("yea") | msg.Contains("yep") | msg.Contains("thats me") | msg.Contains("that's me")) chatStage = 2;
-                    else if (msg.Contains("no") | msg.Contains("nope") | msg.Contains("not")) chatStage = 3;
+                    if (msg.Contains("yes") || msg.Contains("yea") || msg.Contains("yep") || msg.Contains("thats me") || msg.Contains("that's me")) chatStage = 2;
+                    else if (msg.Contains("no") || msg.Contains("nope") || msg.Contains("not")) chatStage = 3;
                     else chatStage = 4;
 
                     chatScript2();


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. 
A bugs, found using PVS-Studio:

- V3093 The '|' operator evaluates both operands. Perhaps a short-circuit '||' operator should be used instead. WebChat1999.cs 146
- V3093 The '|' operator evaluates both operands. Perhaps a short-circuit '||' operator should be used instead. WebChat1999.cs 147

I think it not necessary to use implication here